### PR TITLE
Added argument passing to slack-for-linux

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -1,14 +1,17 @@
 (function () {
 	'use strict';
+	// Load in our dependencies
 	var fs = require('fs');
 	var gui = require('nw.gui');
 	var url = require('url');
 	var _ = require('underscore');
 	var getUri = require('get-uri');
+	var program = require('commander');
 	// DEV: Relative paths are from perspective of `views/index.html` for `index.js`
 	var SlackWindow = require('../js/slack-window.js');
 	var pkg = require('../../package.json');
 
+	// Define our constants
 	var LOCAL_STORAGE_KEY_CURRENT_DOMAIN = 'currentDomain';
 	var SLACK_DOMAIN = 'slack.com';
 	var SLACK_LOGIN_URL = 'https://slack.com/signin';
@@ -17,6 +20,14 @@
 	var win = gui.Window.get();
 	var validSlackSubdomain = /(.+)\.slack.com/i;
 	var slackDownloadHostname = 'files.slack.com';
+
+	// Interpet our CLI arguments
+	// DEV: We need to coerce `nw.js'` arguments as `commander` expects normal (`['node', 'slack-for-linux', '--help']`)
+	//   but `nw.js` only provides arguments themselves (e.g. `--help`)
+	var argv = ['nw', pkg.name].concat(gui.App.argv);
+	program
+		.version(pkg.version)
+		.parse(argv);
 
 	win.on('new-win-policy', function (frame, urlStr, policy) {
 		// Determine where the request is to

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "main": "app/views/index.html",
   "dependencies": {
+    "commander": "^2.8.1",
     "favico.js": "^0.3.8",
     "get-uri": "^0.1.3",
     "nw": "0.12.1",

--- a/run.js
+++ b/run.js
@@ -2,5 +2,12 @@
 // Load in our dependencies
 var spawn = require('child_process').spawn;
 
+// Define `nw` to invoke on the current directory
+var args = ['.'];
+
+// Append all arguments after our node invocation
+// e.g. `node run.js --version` -> `--version`
+args = args.concat(process.argv.slice(2));
+
 // Run our task and output stdout/stderr to parent
-spawn('./node_modules/.bin/nw', ['.'], {cwd: __dirname, stdio: [0, 1, 2]});
+spawn('./node_modules/.bin/nw', args, {cwd: __dirname, stdio: [0, 1, 2]});


### PR DESCRIPTION
As promised in #46, we are adding argument parsing over this weekend. In this PR:

- Added `commander.js` to interpret `slack-for-linux` arguments
    - Currently, we are using the defaults of `--help` and `--version`
- Added argument passing from `js` context to `nw` context in `run.js`

```bash
$ slack-for-linux --version
[8506:0531/234525:ERROR:browser_main_loop.cc(170)] Running without the SUID sandbox! See https://code.google.com/p/chromium/wiki/LinuxSUIDSandboxDevelopment for more information on developing with the sandbox on.
1.4.3
$ slack-for-linux --help
[8670:0531/234927:ERROR:browser_main_loop.cc(170)] Running without the SUID sandbox! See https://code.google.com/p/chromium/wiki/LinuxSUIDSandboxDevelopment for more information on developing with the sandbox on.

  Usage: slack-for-linux [options]

  Options:

    -h, --help     output usage information
    -V, --version  output the version number

```

**Notes:**

The current `--help` and `--version` feel janky because we are opening a window only to immediately close it. This is due to `nw.js'` default behavior of loading a webpage. I suggest we move to a model where we have `show: false` for the original window. Then, after parsing arguments, we can open a new window.

/cc @wlaurance 