### PR TITLE
Replaced old URL references with organization references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-slack-for-linux [![Build Status](https://travis-ci.org/wlaurance/slack-for-linux.svg?branch=master)](https://travis-ci.org/wlaurance/slack-for-linux)
+slack-for-linux [![Build Status](https://travis-ci.org/slack-for-linux/slack-for-linux.svg?branch=master)](https://travis-ci.org/slack-for-linux/slack-for-linux)
 =============
 
 Slack client for linux 64. Uses Node Webkit
@@ -39,7 +39,7 @@ Running and Developing
 ####Clone the repo
 
 ```
-git clone git@github.com:wlaurance/slack-for-linux.git && cd slack-for-linux
+git clone git@github.com:slack-for-linux/slack-for-linux.git && cd slack-for-linux
 ```
 
 ####Install deps


### PR DESCRIPTION
We had a few lingering `wlaurance/slack-for-linux` references that 2dd2d089787ecab37303d07acbb1cc1ccd122cb6 missed. For reference, always use `git grep -i` when cleaning up code in a repo:

```bash
$ git grep -i wlaurance
README.md:1:slack-for-linux [![Build Status](https://travis-ci.org/wlaurance/slack-for-linux.svg?branch=master)](https://travis-ci.org/wlaurance/slack-for-linux)
README.md:42:git clone git@github.com:wlaurance/slack-for-linux.git && cd slack-for-linux
package.json:15:    "url": "https://github.com/wlaurance"
```

In this PR:

- Updated old `wlaurance/slack-for-linux` references with `slack-for-linux/slack-for-linux` references

/cc @wlaurance 