### PR TITLE
Added release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,36 @@
-1.2.0
------
-- Added dev environment linting and editorconfig and code cleanup ([@twolfson](https://github.com/twolfson))
-- Open to previously signed in team ([@canuc](https://github.com/canuc))
+## slack-for-linux changelog
 
-1.1.1
------
+### v1.5.0 (2015/06/02 23:17 +00:00)
+- [#64](https://github.com/slack-for-linux/slack-for-linux/pull/64) Added argument passing to slack-for-linux (@twolfson)
+- [#67](https://github.com/slack-for-linux/slack-for-linux/pull/67) Added CONTRIBUTING.md (@twolfson)
+- [#63](https://github.com/slack-for-linux/slack-for-linux/pull/63) Remove line from readme (@wlaurance)
 
-Features:
+### v1.4.2 (2015/05/28 15:20 +00:00)
+- [#52](https://github.com/slack-for-linux/slack-for-linux/pull/52) Locked down nw.js version (@twolfson)
 
-- Open external links in system default browser ([@canuc](https://github.com/canuc))
-- Add tray icon with visibility toggling ([@twolfson](https://github.com/twolfson))
+### v1.4.1 (2015/05/05 22:44 +00:00)
+- [#45](https://github.com/slack-for-linux/slack-for-linux/pull/45) Add better install logging and fixed global nested npm install (@twolfson)
+- [#41](https://github.com/slack-for-linux/slack-for-linux/pull/41) Change the app name (@wlaurance)
+
+### v1.4.0 (2015/04/29 01:44 +00:00)
+- [#30](https://github.com/slack-for-linux/slack-for-linux/pull/30) Added multi team support (@twolfson)
+
+### v1.2.2 (2015/04/29 00:50 +00:00)
+- [#29](https://github.com/slack-for-linux/slack-for-linux/pull/29) Added requirement for node>=0.10 (@twolfson)
+- [#33](https://github.com/slack-for-linux/slack-for-linux/pull/33) Added plugin flag to enable Flash. Fixes #32 (@twolfson)
+- [#26](https://github.com/slack-for-linux/slack-for-linux/pull/26) Fix download interaction. Fixes #25 (@twolfson)
+- [#24](https://github.com/slack-for-linux/slack-for-linux/pull/24) Added favicon notifications (@twolfson)
+- [#23](https://github.com/slack-for-linux/slack-for-linux/pull/23) Relocated closure variables into function (@twolfson)
+
+### v1.2.1 (2015/03/09 17:45 +00:00)
+- [#19](https://github.com/slack-for-linux/slack-for-linux/pull/19) Fixed Slack's redirect URL (@twolfson)
+
+### v1.2.0 (2015/01/06 17:13 +00:00)
+- [#11](https://github.com/slack-for-linux/slack-for-linux/pull/11) Sign back in to last team on relaunch (@canuc)
+- [#14](https://github.com/slack-for-linux/slack-for-linux/pull/14) Added jscs for style checking (@twolfson)
+- [#10](https://github.com/slack-for-linux/slack-for-linux/pull/10) Moved to grunt linters and added `.editorconfig` linting (@twolfson)
+- [#8](https://github.com/slack-for-linux/slack-for-linux/pull/8) Fixed up various one-off discrepencies (e.g. whitespace, shebang) (@twolfson)
+
+### v0.1.0 (2014/12/16 14:10 +00:00)
+- [#3](https://github.com/slack-for-linux/slack-for-linux/pull/3) Fix for external urls launching within new webview window (@canuc)
+- [#2](https://github.com/slack-for-linux/slack-for-linux/pull/2) Fix for the iframe being small on launch (@canuc)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "slack-for-linux": "./run.js"
   },
   "devDependencies": {
+    "github-changes": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Exit on first error
+set -e
+
+# Parse our parameters
+version="$1"
+
+# If a version wasn't found, complain and leave
+if test -z "$version"; then
+	echo "No \`version\` was provided to \`release.sh\`. Please provide one." 1>&2
+	echo "Usage: ./release.sh <version>" 1>&2
+	echo "  version: Can be semver, major, minor, or patch" 1>&2
+	exit 1
+fi
+
+# Verify `github-changes` is installed
+if ! test -f "./node_modules/.bin/github-changes"; then
+	echo "Couldn't find \`github-changes\` executable. Please verify \`npm install\` has been run." 1>&2
+	exit 1
+fi
+
+# Update our package and add a git commit via `npm`
+npm version "$version"
+
+# Grab our new semver
+semver="$(node --eval "console.log('v' + require('./package.json').version);")"
+
+# Generate a new CHANGELOG
+./node_modules/.bin/github-changes --title "slack-for-linux changelog" \
+	--owner slack-for-linux --repository slack-for-linux \
+	--only-pulls --use-commit-body -n "$semver"
+
+# Append our CHANGELOG edit to the git commit
+git add CHANGELOG.md
+git commit --amend --no-edit
+
+# Publish our changes
+git push origin master
+git push origin --tags
+npm publish


### PR DESCRIPTION
In #59, we discussed the current steps taken to perform a release. This PR automates those steps to guarantee consistent releases across contributors. In this PR:

- Added `github-changes`
- Added `release.sh`, which leverages the steps discussed in #59 
- Updated `CHANGELOG.md` to match current release information
- Closes #59 

/cc @wlaurance 