### PR TITLE
Added commit and feature notes for pull requests to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ When opening a pull request:
 
 - If there was an original issue, then please provide a link to
 - Otherwise, please provide description that follows the guidelines from [Issues](#issues)
+- Please focus on 1 feature/patch at a time in a pull request
+	- If multiple features/patches, consider creating multiple pull requests for each one
+- Please collapse/squash new commits in a pull request into 1 commit
+	- If this depends on another pull request, do not collapse/squash that pull request's commit into this one's
 
 # Contributing
 Interested in contributing? Great, we are always looking for more great people.


### PR DESCRIPTION
In #74, we encountered our first occurrence of squashing commits. While this isn't a problem since it's easy to communicate with developers, it's nice to avoid the extra message about squashing commits.

This PR attempts to resolve the squashing commits conversation by adding it to the `CONTRIBUTING.md`. In this PR:

- Added commit and feature notes for pull requests to `CONTRIBUTING.md`

/cc @wlaurance 